### PR TITLE
exclude the json/jsonl in the inference_mmu.py

### DIFF
--- a/inference_mmu.py
+++ b/inference_mmu.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 
     temperature = 0.8  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
     top_k = 1  # retain only the top_k most likely tokens, clamp others to have 0 probability
-    file_list = os.listdir(config.mmu_image_root)
+    file_list = [f for f in os.listdir(config.mmu_image_root) if f.lower().endswith(('.png', '.jpg', '.jpeg'))]
     responses = ['' for i in range(len(file_list))]
     images = []
     config.question = config.question.split(' *** ')


### PR DESCRIPTION
This PR fixes an issue in inference_mmu.py where the script attempts to read all files in the specified directory indiscriminately. If the directory contains non-image files such as .json or .jsonl, the script fails due to unsupported formats.

To resolve this, I modified the file loading logic to filter only supported image files, preventing errors when irrelevant files are present in the directory.

![QQ_1748088180023](https://github.com/user-attachments/assets/f402a1f0-ae8b-4f22-a909-d7a772d3cbbe)
